### PR TITLE
Dispatch fireSubscribers in NavigationStore

### DIFF
--- a/boilerplate/src/models/navigation-store/navigation-store.ts
+++ b/boilerplate/src/models/navigation-store/navigation-store.ts
@@ -41,6 +41,7 @@ export const NavigationStoreModel = NavigationEvents.named("NavigationStore")
     dispatch(action: NavigationAction, shouldPush: boolean = true) {
       const previousNavState = shouldPush ? self.state : null
       self.state = RootNavigator.router.getStateForAction(action, previousNavState) || self.state
+      self.fireSubscribers(action, previousNavState, self.state)
       return true
     },
 


### PR DESCRIPTION
We need to actually dispatch the `fireSubscribers` from NavigationEvents in order for navigation's `addListener` to work.

```
const fireSubscribers = (action: any, oldState: any, newState: any) => {
    // tell each subscriber out this
    subs.forEach(subscriber => {
      subscriber({
        type: "action",
        action,
        state: newState,
        lastState: oldState,
      })
    })
  }
```
in `navigation-events.ts` - this wasn't included in the NavigationStore `dispatch` action :doh: