### PR TITLE
Add: @storybook/addon-storyshots without puppeteer dependency

### DIFF
--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -34,7 +34,7 @@
     "validate.js": "0.12.0"
   },
   "devDependencies": {
-    "@storybook/addon-storyshots": "github:leonskim/addon-storyshots",
+    "@storybook/addon-storyshots": "github:infinitered/addon-storyshots",
     "@storybook/react-native": "3.4.3",
     "@types/jest": "22.2.3",
     "@types/ramda": "0.25.28",

--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -34,7 +34,7 @@
     "validate.js": "0.12.0"
   },
   "devDependencies": {
-    "@storybook/addon-storyshots": "3.4.3",
+    "@storybook/addon-storyshots": "github:leonskim/addon-storyshots",
     "@storybook/react-native": "3.4.3",
     "@types/jest": "22.2.3",
     "@types/ramda": "0.25.28",


### PR DESCRIPTION
- Issue #19 (puppeteer is now a dependency)
- Added a customized `@storybook/addon-storyshots` without `puppeteer` dependency
- Repo: https://github.com/infinitered/addon-storyshots

![screen shot 2018-06-05 at 4 40 02 am](https://user-images.githubusercontent.com/8325407/40939044-7f972d86-687e-11e8-991b-07d14d3f9894.png)
