### PR TITLE
Fix hot reloading on storybook

### DIFF
--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -20,7 +20,6 @@
     "storybook": "storybook start -p 9001 --skip-packager"
   },
   "dependencies": {
-    "@types/node": "^10.3.0",
     "apisauce": "0.14.3",
     "lodash.throttle": "4.1.1",
     "mobx": "4.2.1",

--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -20,6 +20,7 @@
     "storybook": "storybook start -p 9001 --skip-packager"
   },
   "dependencies": {
+    "@types/node": "^10.3.0",
     "apisauce": "0.14.3",
     "lodash.throttle": "4.1.1",
     "mobx": "4.2.1",

--- a/boilerplate/src/app/main.tsx.ejs
+++ b/boilerplate/src/app/main.tsx.ejs
@@ -16,6 +16,11 @@ const APP_NAME = "<%= props.name %>"
 // ⚠️ Leave this as `false` when checking into git.
 const SHOW_STORYBOOK = false
 
+// appease the typescript overlords
+declare global {
+  var module
+}
+
 if (SHOW_STORYBOOK && __DEV__) {
   // 🎗 REMINDER: Storybook has a server you need to run from a terminal window.
   //

--- a/boilerplate/src/app/main.tsx.ejs
+++ b/boilerplate/src/app/main.tsx.ejs
@@ -4,7 +4,7 @@
 
 import { AppRegistry } from "react-native"
 import { RootComponent } from "./root-component"
-import { StorybookUI } from "../../storybook"
+import { StorybookUIRoot } from "../../storybook"
 
 /**
  * This needs to match what's found in your app_delegate.m and MainActivity.java.
@@ -21,7 +21,7 @@ if (SHOW_STORYBOOK && __DEV__) {
   //
   // $> yarn run storybook
   //
-  AppRegistry.registerComponent(APP_NAME, () => StorybookUI)
+  AppRegistry.registerComponent(APP_NAME, () => StorybookUIRoot)
 } else {
   // load our app
   AppRegistry.registerComponent(APP_NAME, () => RootComponent)

--- a/boilerplate/src/views/shared/button/button.story.tsx
+++ b/boilerplate/src/views/shared/button/button.story.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from "@storybook/react-native"
 import { StoryScreen, Story, UseCase } from "../../../../storybook/views"
 import { Button } from "./"
 
-storiesOf("Button")
+storiesOf("Button", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Style Presets", () => (
     <Story>

--- a/boilerplate/src/views/shared/checkbox/checkbox.story.tsx
+++ b/boilerplate/src/views/shared/checkbox/checkbox.story.tsx
@@ -5,7 +5,7 @@ import { StoryScreen, Story, UseCase } from "../../../../storybook/views"
 import { Checkbox } from "./"
 import { Toggle } from "react-powerplug"
 
-storiesOf("Checkbox")
+storiesOf("Checkbox", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Behaviour", () => (
     <Story>

--- a/boilerplate/src/views/shared/form-row/form-row.story.tsx
+++ b/boilerplate/src/views/shared/form-row/form-row.story.tsx
@@ -4,7 +4,7 @@ import { StoryScreen, Story, UseCase } from "../../../../storybook/views"
 import { FormRow } from "./form-row"
 import { Text } from "../text"
 
-storiesOf("FormRow")
+storiesOf("FormRow", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Assembled", () => (
     <Story>

--- a/boilerplate/src/views/shared/header/header.story.tsx
+++ b/boilerplate/src/views/shared/header/header.story.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from "@storybook/react-native"
 import { StoryScreen, Story, UseCase } from "../../../../storybook/views"
 import { Header } from "./header"
 
-storiesOf("Header")
+storiesOf("Header", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Behavior", () => (
     <Story>

--- a/boilerplate/src/views/shared/icon/icon.story.tsx
+++ b/boilerplate/src/views/shared/icon/icon.story.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from "@storybook/react-native"
 import { StoryScreen, Story, UseCase } from "../../../../storybook/views"
 import { Icon } from "./icon"
 
-storiesOf("Icon")
+storiesOf("Icon", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Names", () => (
     <Story>

--- a/boilerplate/src/views/shared/switch/switch.story.tsx
+++ b/boilerplate/src/views/shared/switch/switch.story.tsx
@@ -5,7 +5,7 @@ import { StoryScreen, Story, UseCase } from "../../../../storybook/views"
 import { Toggle } from "react-powerplug"
 import { Switch } from "."
 
-storiesOf("Switch")
+storiesOf("Switch", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Behaviour", () => (
     <Story>

--- a/boilerplate/src/views/shared/text-field/text-field.story.tsx
+++ b/boilerplate/src/views/shared/text-field/text-field.story.tsx
@@ -5,7 +5,7 @@ import { Text } from "../text"
 import { TextField } from "./"
 import { State } from "react-powerplug"
 
-storiesOf("TextField")
+storiesOf("TextField", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Labelling", () => (
     <Story>

--- a/boilerplate/src/views/shared/text/text.story.tsx
+++ b/boilerplate/src/views/shared/text/text.story.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from "@storybook/react-native"
 import { StoryScreen, Story, UseCase } from "../../../../storybook/views"
 import { Text } from "./text"
 
-storiesOf("Text")
+storiesOf("Text", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Style Presets", () => (
     <Story>

--- a/boilerplate/src/views/shared/wallpaper/wallpaper.story.tsx
+++ b/boilerplate/src/views/shared/wallpaper/wallpaper.story.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from "@storybook/react-native"
 import { StoryScreen, Story, UseCase } from "../../../../storybook/views"
 import { Wallpaper } from "./wallpaper"
 
-storiesOf("Wallpaper")
+storiesOf("Wallpaper", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Style Presets", () => (
     <Story>

--- a/boilerplate/storybook/storybook.ts
+++ b/boilerplate/storybook/storybook.ts
@@ -1,7 +1,0 @@
-import { getStorybookUI, configure } from "@storybook/react-native"
-
-configure(() => {
-  require("./storybook-registry")
-})
-
-export const StorybookUI = getStorybookUI({ port: 9001, host: "localhost", onDeviceUI: true })

--- a/boilerplate/storybook/storybook.tsx
+++ b/boilerplate/storybook/storybook.tsx
@@ -1,0 +1,15 @@
+import React, { Component } from 'react'
+import { getStorybookUI, configure } from "@storybook/react-native"
+
+configure(() => {
+  require("./storybook-registry")
+})
+
+const StorybookUI = getStorybookUI({ port: 9001, host: "localhost", onDeviceUI: true })
+
+// RN hot module must be in a class for HMR
+export class StorybookUIRoot extends Component {
+  render() {
+    return <StorybookUI />
+  }
+}

--- a/templates/component.story.tsx.ejs
+++ b/templates/component.story.tsx.ejs
@@ -7,7 +7,7 @@ import { StoryScreen, Story, UseCase } from "../../../../storybook/views"
 <% } -%>
 import { <%= props.pascalName %> } from "./"
 
-storiesOf("<%= props.pascalName %>")
+storiesOf("<%= props.pascalName %>", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Style Presets", () => (
     <Story>


### PR DESCRIPTION
- Issue #32 (Hot reloading on storybook is not working)
- `storiesOf()` takes a second parameter so I've added it.
- FIXED ~~(WIP) Unlike the generated app, hot reloading doesn't work on storybook.~~
  - It reloads but doesn't refresh. It works when enabling `Live Reloading`, of course. It's just not hot.
  - https://github.com/bvic23/babel-plugin-functional-hmr looked promising so I gave it a shot but didn't work
  - Refs:
    - https://github.com/facebook/react-native/issues/10991
    - https://github.com/storybooks/storybook/issues/2081
- Added a root component for StorybookUI since RN hot module must be in a class for HMR
- Hot reloading example (GIF):
![bowser_storybook](https://user-images.githubusercontent.com/8325407/40976625-a2e17220-6909-11e8-96c8-cdd745e026fb.gif)
