### PR TITLE
Polish screen generator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ignite-ir-boilerplate-bowser",
-  "version": "1.0.0-alpha.4",
+  "version": "1.0.0-alpha.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/infinitered/ignite-ir-boilerplate-bowser"
   },
   "scripts": {
-    "lint": "standard",
+    "lint": "tslint -p .",
     "test": "jest",
     "watch": "jest --runInBand --watch",
     "coverage": "jest --runInBand --coverage",

--- a/templates/screen.ejs
+++ b/templates/screen.ejs
@@ -1,10 +1,26 @@
 import * as React from "react"
 import { observer } from "mobx-react"
+import { ViewStyle } from "react-native"
+<% if (props.newDomain) { -%>
+import { Text } from "../shared/text"
+import { Screen } from "../shared/screen"
+import { color } from "../../theme"
+<% } else if (props.sharedComponent) { -%>
+import { Text } from "../text"
+import { Screen } from "../screen"
+import { color } from "../../../theme"
+<% } else { -%>
 import { Text } from "../../shared/text"
-import { NavigationScreenProps } from "react-navigation"
 import { Screen } from "../../shared/screen"
+import { color } from "../../../theme"
+<% } -%>
+import { NavigationScreenProps } from "react-navigation"
 
 export interface <%= props.pascalName %>ScreenProps extends NavigationScreenProps<{}> {
+}
+
+const ROOT: ViewStyle = {
+  backgroundColor: color.palette.black,
 }
 
 // @inject("mobxstuff")
@@ -12,8 +28,8 @@ export interface <%= props.pascalName %>ScreenProps extends NavigationScreenProp
 export class <%= props.pascalName %> extends React.Component<<%= props.pascalName %>ScreenProps, {}> {
   render () {
     return (
-      <Screen preset="fixedCenter">
-        <Text preset="header" tx="<%= props.pascalName %>.header" />
+      <Screen style={ROOT} preset="fixedCenter">
+        <Text preset="header" tx="<%= props.camelName %>.header" />
       </Screen>
     )
   }

--- a/test/generators-integration.test.js
+++ b/test/generators-integration.test.js
@@ -6,7 +6,7 @@ const IGNITE = 'ignite'
 const APP = 'IntegrationTest'
 const BOILERPLATE = `${__dirname}/../`
 // calling the ignite cli takes a while
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 600000
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 800000
 
 describe('with a linter', () => {
   // creates a new temp directory
@@ -79,11 +79,12 @@ describe('generators', () => {
     expect(lint.stderr).toBe('')
   })
 
-  // test('generate screen works', async () => {
-  //   await execa(IGNITE, ['g', 'screen', 'Test'], { preferLocal: false })
-  //   expect(jetpack.exists('App/Containers/TestScreen.js')).toBe('file')
-  //   expect(jetpack.exists('App/Containers/TestScreenStyle.js')).toBe('file')
-  //   const lint = await execa('npm', ['run', 'lint'])
-  //   expect(lint.stderr).toBe('')
-  // })
+  test('generates a screen', async () => {
+    const simpleScreen = 'test'
+    await execa(IGNITE, ['g', 'screen', simpleScreen, '--folder', 'views'], { preferLocal: false })
+    expect(jetpack.exists(`src/views/${simpleScreen}/${simpleScreen}-screen.tsx`)).toBe('file')
+    expect(jetpack.exists(`src/views/${simpleScreen}/index.ts`)).toBe('file')
+    const lint = await execa('npm', ['-s', 'run', 'lint'])
+    expect(lint.stderr).toBe('')
+  })
 })


### PR DESCRIPTION
## Overview

This just polishes up the screen generator that was already in place. [Trello](https://trello.com/c/b5mKF4a5/1-screen-generator-25)

Changes include:
- camelCase instead of pascalCase for the entry in AppNavigator
- `--folder` or `--f` option which allows for easier integration tests (shamelessly stole this code from @carlinisaacson )
- Conditional imports for `Text` `Screen` and `color` since they're imported from different places depending on where the user placed the screen
- camelCase instead of pascalCase in `i18n` translation string
- Added a basic `ROOT` style