### PR TITLE
Fix: support sed command for non-MacOS

### DIFF
--- a/boilerplate.js
+++ b/boilerplate.js
@@ -1,5 +1,6 @@
 const { merge, pipe, assoc, omit, __ } = require('ramda')
 const { getReactNativeVersion } = require('./lib/react-native-version')
+const os = require('os')
 
 /**
  * Is Android installed?
@@ -162,7 +163,8 @@ async function install (context) {
     spinner.text = `▸ setting up splash screen: linking`
     await system.spawn(`react-native link react-native-splash-screen`, { stdio: 'ignore' })
     spinner.text = `▸ setting up splash screen: configuring`
-    await system.run(`sed -i '' 's/SplashScreenPatch/${name}/g' ${process.cwd()}/patches/splash-screen/splash-screen.patch`, { stdio: 'ignore' })
+    const backupExtension = (os.platform() === 'darwin') ? '\'\'' : ''
+    await system.run(`sed -i ${backupExtension} 's/SplashScreenPatch/${name}/g' ${process.cwd()}/patches/splash-screen/splash-screen.patch`, { stdio: 'ignore' })
     spinner.text = `▸ setting up splash screen: cleaning`
     await system.run(`git apply ${process.cwd()}/patches/splash-screen/splash-screen.patch`, { stdio: 'ignore' })
     filesystem.remove(`${process.cwd()}/patches/splash-screen`)


### PR DESCRIPTION
- Support `sed` command for non-MacOS while setting up splash screen by separating backup extension parameter
- For the reviewers: Since you guys reviewed the splash screen PR, I'm adding you. Thanks!