### PR TITLE
HOLD: installing splash screen

### DIFF
--- a/boilerplate.js
+++ b/boilerplate.js
@@ -154,6 +154,7 @@ async function install (context) {
   await system.spawn('react-native link', { stdio: 'ignore' })
   spinner.stop()
 
+  /* TODO: fix splash screen issues
   async function patchSplashScreen () {
     spinner.text = `▸ setting up splash screen`
     spinner.start()
@@ -169,6 +170,7 @@ async function install (context) {
   }
   await patchSplashScreen()
   spinner.stop()
+  */
 
   // pass long the debug flag if we're running in that mode
   const debugFlag = parameters.options.debug ? '--debug' : ''


### PR DESCRIPTION
Since there are a couple of issues that make the generated project messy, we need to block this until the issues are solved.