### PR TITLE
📌 pins react-navigation until we have time to figure it out

### DIFF
--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -28,7 +28,7 @@
     "ramda": "0.25.0",
     "react-native-i18n": "2.0.12",
     "react-native-keychain": "3.0.0-rc.3",
-    "react-navigation": "^2.0.4",
+    "react-navigation": "2.0.4",
     "reactotron-mst": "2.0.0-beta.2",
     "reactotron-react-native": "2.0.0-beta.2",
     "validate.js": "0.12.0"


### PR DESCRIPTION
There's a breaking change somewhere between 2.0.4 and 2.3.... this buys us time while we dig in.

