### PR TITLE
Fix: splash screen issues by pinning version

### DIFF
--- a/boilerplate.js
+++ b/boilerplate.js
@@ -155,16 +155,15 @@ async function install (context) {
   await system.spawn('react-native link', { stdio: 'ignore' })
   spinner.stop()
 
-  /* TODO: fix splash screen issues
   async function patchSplashScreen () {
     spinner.text = `▸ setting up splash screen`
     spinner.start()
     spinner.text = `▸ setting up splash screen: installing package`
-    await system.run(`yarn add react-native-splash-screen`, { stdio: 'ignore' })
+    await system.run(`yarn add react-native-splash-screen@3.0.6`, { stdio: 'ignore' })
     spinner.text = `▸ setting up splash screen: linking`
     await system.spawn(`react-native link react-native-splash-screen`, { stdio: 'ignore' })
     spinner.text = `▸ setting up splash screen: configuring`
-    const backupExtension = (os.platform() === 'darwin') ? '\'\'' : ''
+    const backupExtension = (os.platform() === 'darwin') ? '""' : ''
     await system.run(`sed -i ${backupExtension} 's/SplashScreenPatch/${name}/g' ${process.cwd()}/patches/splash-screen/splash-screen.patch`, { stdio: 'ignore' })
     spinner.text = `▸ setting up splash screen: cleaning`
     await system.run(`git apply ${process.cwd()}/patches/splash-screen/splash-screen.patch`, { stdio: 'ignore' })
@@ -172,7 +171,6 @@ async function install (context) {
   }
   await patchSplashScreen()
   spinner.stop()
-  */
 
   // pass long the debug flag if we're running in that mode
   const debugFlag = parameters.options.debug ? '--debug' : ''


### PR DESCRIPTION
- Task: https://trello.com/c/uSt9ti2S/19-25-splash-screen-issues
- This should fix:
  - #40 - Error: Command failed: sed -i '' while creating new project
  - #42 - Splash screen linking issue on android
- There's no problem running on iOS but having and issue on Android when running it with `react-native run-android`. It seems like my npm environment causes it(https://github.com/react-community/create-react-native-app/issues/603) @skellock @ryanlntn Could you guys test this branch?