### PR TITLE
Splash in boilerplate package

### DIFF
--- a/boilerplate.js
+++ b/boilerplate.js
@@ -158,10 +158,6 @@ async function install (context) {
   async function patchSplashScreen () {
     spinner.text = `▸ setting up splash screen`
     spinner.start()
-    spinner.text = `▸ setting up splash screen: installing package`
-    await system.run(`yarn add react-native-splash-screen@3.0.6`, { stdio: 'ignore' })
-    spinner.text = `▸ setting up splash screen: linking`
-    await system.spawn(`react-native link react-native-splash-screen`, { stdio: 'ignore' })
     spinner.text = `▸ setting up splash screen: configuring`
     const backupExtension = (os.platform() === 'darwin') ? '""' : ''
     await system.run(`sed -i ${backupExtension} 's/SplashScreenPatch/${name}/g' ${process.cwd()}/patches/splash-screen/splash-screen.patch`, { stdio: 'ignore' })

--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -28,6 +28,7 @@
     "ramda": "0.25.0",
     "react-native-i18n": "2.0.12",
     "react-native-keychain": "3.0.0-rc.3",
+    "react-native-splash-screen": "3.0.6",
     "react-navigation": "2.0.4",
     "reactotron-mst": "2.0.0-beta.2",
     "reactotron-react-native": "2.0.0-beta.2",

--- a/boilerplate/patches/splash-screen/splash-screen.patch
+++ b/boilerplate/patches/splash-screen/splash-screen.patch
@@ -30508,10 +30508,10 @@ index 88a7c9c..87d2632 100644
  interface RootComponentState {
    rootStore?: RootStore
 @@ -24,6 +25,7 @@ export class RootComponent extends React.Component<{}, RootComponentState> {
++    SplashScreen.hide()
      this.setState({
        rootStore: await setupRootStore(),
      })
-+    SplashScreen.hide()
    }
  
    /**

--- a/boilerplate/storybook/storybook.tsx
+++ b/boilerplate/storybook/storybook.tsx
@@ -1,6 +1,6 @@
-import React from 'react'
+import React from "react"
 import { getStorybookUI, configure } from "@storybook/react-native"
-import SplashScreen from 'react-native-splash-screen'
+import SplashScreen from "react-native-splash-screen"
 
 configure(() => {
   require("./storybook-registry")

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "repository": "infinitered/ignite-ir-boilerplate-bowser",
   "homepage": "https://github.com/infinitered/ignite-ir-boilerplate-bowser",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "files": [
     "boilerplate",
     "commands",


### PR DESCRIPTION
- Moved `react-native-splash-screen` to `package.json.ejs`
- Hide splash screen as soon as root component is mounted since it's the first action (kind of). This will fix #54, https://github.com/infinitered/ignite/issues/1287
- Increased version to apply the latest changes
- Let me merge this first to confirm above fixes are applied and working. Please review although. Thanks!