### PR TITLE
Fix clearOnLoad param usage

### DIFF
--- a/boilerplate/src/services/reactotron/reactotron.ts
+++ b/boilerplate/src/services/reactotron/reactotron.ts
@@ -57,7 +57,6 @@ export class Reactotron {
     this.config = {
       host: "localhost",
       useAsyncStorage: true,
-      clearOnLoad: true,
       ...config,
       state: {
         initial: false,


### PR DESCRIPTION
The `clearOnLoad` param needs to come from the `ReactotronConfig` file and not forced in this file.