### PR TITLE
Fixed sed command for mac

### DIFF
--- a/boilerplate.js
+++ b/boilerplate.js
@@ -173,7 +173,8 @@ async function install (context) {
       spinner.start()
       spinner.text = `▸ setting up splash screen: configuring`
       const backupExtension = (os.platform() === 'darwin') ? '""' : ''
-      await system.run(`sed -i ${backupExtension} 's/SplashScreenPatch/${name}/g' ${process.cwd()}/patches/splash-screen/splash-screen.patch`, { stdio: 'ignore' })
+      target = `${process.cwd()}/patches/splash-screen/splash-screen.patch`
+      await system.run(`sed -e 's/SplashScreenPatch/${name}/g' ${target} > x.tmp && mv x.tmp ${target}`, { stdio: 'ignore' })
       spinner.text = `▸ setting up splash screen: cleaning`
       await system.run(`git apply ${process.cwd()}/patches/splash-screen/splash-screen.patch`, { stdio: 'ignore' })
       filesystem.remove(`${process.cwd()}/patches/splash-screen`)


### PR DESCRIPTION
Error:

``` bash
⠹ ▸ setting up splash screen: configuringan error occured while installing ignite-ir-boilerplate-bowser boilerplate.
Error: Command failed: sed -i "" 's/SplashScreenPatch/PigeonPost/g' /Users/mark/PigeonPost/PigeonPost/patches/splash-screen/splash-screen.patch
sed: can't read s/SplashScreenPatch/PigeonPost/g: No such file or directory
```

This is a little more gross than the current implementation, however, it breaks the command on my mac. I'd overwrite it locally, but ignite cli is intent on downloading a new ignite-ir-boilerplate-bowser every time it creates a new app and thus pulls in the old code.

This implementation I believe fixes the issue, although it's untested.

Solution derived from here: https://stackoverflow.com/questions/5171901/sed-command-find-and-replace-in-file-and-overwrite-file-doesnt-work-it-empties

Specifically:

``` bash
Quite a lot of seds have the -i option, but not all of them; the posix sed is one which doesn't. If you're aiming for portability, therefore, it's best avoided.
```