### PR TITLE
Add storybook instructions to README

### DIFF
--- a/boilerplate/README.md
+++ b/boilerplate/README.md
@@ -127,6 +127,14 @@ This directory will hold your Jest configs and mocks, as well as your [storyshot
 **ignite**
 The `ignite` directory stores all things Ignite, including CLI and boilerplate items. Here you will find generators, plugins and examples to help you get started with React Native.
 
+## Running Storybook
+From the command line in your generated app's root directory, enter `yarn run storybook`
+This starts up the storybook server.
+
+In `src/app/main.tsx`, change `SHOW_STORYBOOK` to `true` and reload the app.
+
+For Visual Studio Code users, there is a handy extension that makes it easy to load Storybook use cases into a running emulator via tapping on items in the editor sidebar. Install the `React Native Storybook` extension by `Orta`, hit `cmd + shift + P` and select "Reconnect Storybook to VSCode". Expand the STORYBOOK section in the sidebar to see all use cases for components that have `.story.tsx` files in their directories.
+
 ## Previous Boilerplates
 
 * [2017 aka Andross](https://github.com/infinitered/ignite-ir-boilerplate-andross)


### PR DESCRIPTION
https://trello.com/c/rI1tF8Ls/24-add-storybook-instructions-to-default-readmemd

Adds instructions to the generated README file about how to run Storybook.