### PR TITLE
Add reactotron to storybook

### DIFF
--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -61,7 +61,14 @@
     "typescript": "2.8.3"
   },
   "jest": {
-    "preset": "jest-preset-ignite"
+    "preset": "jest-preset-ignite",
+    "testPathIgnorePatterns": [
+      "/e2e/",
+      "/node_modules"
+    ],
+    "globals": {
+      "__TEST__": true
+    }
   },
   "rnpm": {
     "assets": [

--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -63,7 +63,6 @@
   "jest": {
     "preset": "jest-preset-ignite",
     "testPathIgnorePatterns": [
-      "/e2e/",
       "/node_modules"
     ],
     "globals": {

--- a/boilerplate/src/i18n/en.json
+++ b/boilerplate/src/i18n/en.json
@@ -17,5 +17,9 @@
     "title": "What’s In This Stack?",
     "tagLine": "Congratulations, you’ve got a very advanced React Native app template here.  Take advantage of this boilerplate!",
     "reactotron": "Demo Reactotron"
+  },
+  "storybook": {
+    "placeholder": "Placeholder",
+    "field": "Field"
   }
 }

--- a/boilerplate/src/theme/color.ts
+++ b/boilerplate/src/theme/color.ts
@@ -48,4 +48,17 @@ export const color = {
    * Error messages and icons.
    */
   error: palette.angry,
+
+  /**
+   * Storybook background for Text stories, or any stories where 
+   * the text color is color.text, which is white by default, and does not show
+   * in Stories against the default white background
+  */
+  storybookDarkBg: palette.black,
+
+  /**
+   * Storybook text color for stories that display Text components against the
+   * white background
+  */
+   storybookTextColor: palette.black,
 }

--- a/boilerplate/src/views/shared/form-row/form-row.story.tsx
+++ b/boilerplate/src/views/shared/form-row/form-row.story.tsx
@@ -3,6 +3,11 @@ import { storiesOf } from "@storybook/react-native"
 import { StoryScreen, Story, UseCase } from "../../../../storybook/views"
 import { FormRow } from "./form-row"
 import { Text } from "../text"
+import { color } from "../../../theme/color"
+
+const TEXT_STYLE_OVERRIDE = {
+  color: color.storybookTextColor,
+}
 
 storiesOf("FormRow", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
@@ -13,34 +18,34 @@ storiesOf("FormRow", module)
         usage="FormRow has many parts designed to fit together.  Here is what it looks like all assembled."
       >
         <FormRow preset="top">
-          <Text preset="fieldLabel">Hello! I am at the top</Text>
+          <Text preset="fieldLabel" style={TEXT_STYLE_OVERRIDE}>Hello! I am at the top</Text>
         </FormRow>
         <FormRow preset="middle">
-          <Text>
+          <Text style={TEXT_STYLE_OVERRIDE}>
             Lorem ipsum dolor sit amet, consectetur adipisicing elit. Commodi officia quo rerum
             impedit asperiores hic ex quae, quam dolores vel odit doloribus, tempore atque deserunt
             possimus incidunt, obcaecati numquam officiis.
           </Text>
         </FormRow>
         <FormRow preset="middle">
-          <Text preset="secondary">...one more thing</Text>
+          <Text preset="secondary" style={TEXT_STYLE_OVERRIDE}>...one more thing</Text>
         </FormRow>
         <FormRow preset="bottom">
-          <Text>🎉 Footers!</Text>
+          <Text style={TEXT_STYLE_OVERRIDE}>🎉 Footers!</Text>
         </FormRow>
       </UseCase>
       <UseCase text="Alternatives" usage="Less commonly used presets.">
         <FormRow preset="clear">
-          <Text>
+          <Text style={TEXT_STYLE_OVERRIDE}>
             My borders are still there, but they are clear. This causes the text to still align
             properly due to the box model of flexbox.
           </Text>
         </FormRow>
         <FormRow preset="soloRound">
-          <Text>I'm round</Text>
+          <Text style={TEXT_STYLE_OVERRIDE}>I'm round</Text>
         </FormRow>
         <FormRow preset="soloStraight" style={{ marginTop: 10, backgroundColor: "#ffe" }}>
-          <Text>I'm square and have a custom style.</Text>
+          <Text style={TEXT_STYLE_OVERRIDE}>I'm square and have a custom style.</Text>
         </FormRow>
       </UseCase>
     </Story>
@@ -49,34 +54,34 @@ storiesOf("FormRow", module)
     <Story>
       <UseCase text="top" usage="The top of a form.">
         <FormRow preset="top">
-          <Text>Curved borders at the top.</Text>
-          <Text>Nothing below</Text>
+          <Text style={TEXT_STYLE_OVERRIDE}>Curved borders at the top.</Text>
+          <Text style={TEXT_STYLE_OVERRIDE}>Nothing below</Text>
         </FormRow>
       </UseCase>
       <UseCase text="middle" usage="A row in the middle of a form.">
         <FormRow preset="middle">
-          <Text>No curves and empty at the bottom.</Text>
+          <Text style={TEXT_STYLE_OVERRIDE}>No curves and empty at the bottom.</Text>
         </FormRow>
       </UseCase>
       <UseCase text="bottom" usage="The bottom of a form.">
         <FormRow preset="bottom">
-          <Text>Curved at the bottom</Text>
-          <Text>Line at the top.</Text>
+          <Text style={TEXT_STYLE_OVERRIDE}>Curved at the bottom</Text>
+          <Text style={TEXT_STYLE_OVERRIDE}>Line at the top.</Text>
         </FormRow>
       </UseCase>
       <UseCase text="soloRound" usage="A standalone curved form row.">
         <FormRow preset="soloRound">
-          <Text>Curves all around.</Text>
+          <Text style={TEXT_STYLE_OVERRIDE}>Curves all around.</Text>
         </FormRow>
       </UseCase>
       <UseCase text="soloStraight" usage="A standalone straight form row.">
         <FormRow preset="soloStraight">
-          <Text>Curves nowhere.</Text>
+          <Text style={TEXT_STYLE_OVERRIDE}>Curves nowhere.</Text>
         </FormRow>
       </UseCase>
       <UseCase text="clear" usage="Identical dimensions but transparent edges.">
         <FormRow preset="clear">
-          <Text>Curves nowhere.</Text>
+          <Text style={TEXT_STYLE_OVERRIDE}>Curves nowhere.</Text>
         </FormRow>
       </UseCase>
     </Story>

--- a/boilerplate/src/views/shared/header/header.story.tsx
+++ b/boilerplate/src/views/shared/header/header.story.tsx
@@ -1,30 +1,43 @@
 import * as React from "react"
+import { View } from "react-native"
 import { storiesOf } from "@storybook/react-native"
 import { StoryScreen, Story, UseCase } from "../../../../storybook/views"
 import { Header } from "./header"
+import { color } from "../../../theme/color"
+
+const VIEWSTYLE = {
+  flex: 1,
+  backgroundColor: color.storybookDarkBg,
+}
 
 storiesOf("Header", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Behavior", () => (
     <Story>
       <UseCase noPad text="default" usage="The default usage">
-        <Header
-          headerTx="secondExampleScreen.howTo"
-        />
+        <View style={VIEWSTYLE}>
+          <Header
+            headerTx="secondExampleScreen.howTo"
+          />
+        </View>
       </UseCase>
       <UseCase noPad text="leftIcon" usage="A left nav icon">
-        <Header
-          headerTx="secondExampleScreen.howTo"
-          leftIcon="back"
-          onLeftPress={() => window.alert("left nav")}
-        />
+        <View style={VIEWSTYLE}>
+          <Header
+            headerTx="secondExampleScreen.howTo"
+            leftIcon="back"
+            onLeftPress={() => window.alert("left nav")}
+          />
+        </View>
       </UseCase>
       <UseCase noPad text="rightIcon" usage="A right nav icon">
-        <Header
-          headerTx="secondExampleScreen.howTo"
-          rightIcon="bullet"
-          onRightPress={() => window.alert("right nav")}
-        />
+        <View style={VIEWSTYLE}>
+          <Header
+            headerTx="secondExampleScreen.howTo"
+            rightIcon="bullet"
+            onRightPress={() => window.alert("right nav")}
+          />
+        </View>
       </UseCase>
     </Story>
   ))

--- a/boilerplate/src/views/shared/text/text.story.tsx
+++ b/boilerplate/src/views/shared/text/text.story.tsx
@@ -1,27 +1,40 @@
 import * as React from "react"
+import { View } from "react-native"
 import { storiesOf } from "@storybook/react-native"
 import { StoryScreen, Story, UseCase } from "../../../../storybook/views"
+import { color } from "../../../theme/color"
 import { Text } from "./text"
+
+const VIEWSTYLE = {
+  flex: 1,
+  backgroundColor: color.storybookDarkBg,
+}
 
 storiesOf("Text", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Style Presets", () => (
     <Story>
       <UseCase text="default" usage="Used for normal body text.">
-        <Text>Hello!</Text>
-        <Text style={{ paddingTop: 10 }}>
-          Check out{"\n"}
-          my{"\n"}
-          line height
-        </Text>
-        <Text style={{ paddingTop: 10 }}>The quick brown fox jumped over the slow lazy dog.</Text>
-        <Text>$123,456,789.00</Text>
+        <View style={VIEWSTYLE}>
+          <Text>Hello!</Text>
+          <Text style={{ paddingTop: 10 }}>
+            Check out{"\n"}
+            my{"\n"}
+            line height
+          </Text>
+          <Text style={{ paddingTop: 10 }}>The quick brown fox jumped over the slow lazy dog.</Text>
+          <Text>$123,456,789.00</Text>
+        </View>
       </UseCase>
       <UseCase text="bold" usage="Used for bolded body text.">
-        <Text preset="bold">Osnap! I'm puffy.</Text>
+        <View style={VIEWSTYLE}>
+          <Text preset="bold">Osnap! I'm puffy.</Text>
+        </View>
       </UseCase>
       <UseCase text="header" usage="Used for major section headers.">
-        <Text preset="header">Behold!</Text>
+        <View style={VIEWSTYLE}>
+          <Text preset="header">Behold!</Text>
+        </View>
       </UseCase>
     </Story>
   ))
@@ -31,23 +44,31 @@ storiesOf("Text", module)
         text="text"
         usage="Used when you want to pass a value but don't want to open a child."
       >
-        <Text text="Heyo!" />
+        <View style={VIEWSTYLE}>
+          <Text text="Heyo!" />
+        </View>
       </UseCase>
       <UseCase text="tx" usage="Used for looking up i18n keys.">
-        <Text tx="common.ok" />
-        <Text tx="omglol" />
+        <View style={VIEWSTYLE}>
+          <Text tx="common.ok" />
+          <Text tx="omglol" />
+        </View>
       </UseCase>
       <UseCase
         text="children"
         usage="Used like you would normally use a React Native <Text> component."
       >
-        <Text>Passing strings as children.</Text>
+        <View style={VIEWSTYLE}>
+          <Text>Passing strings as children.</Text>
+        </View>
       </UseCase>
       <UseCase text="nested children" usage="You can embed them and change styles too.">
-        <Text>
-          {" "}
-          Hello <Text preset="bold">bolded</Text> World.
-        </Text>
+        <View style={VIEWSTYLE}>
+          <Text>
+            {" "}
+            Hello <Text preset="bold">bolded</Text> World.
+          </Text>
+        </View>
       </UseCase>
     </Story>
   ))

--- a/boilerplate/storybook/storybook.tsx
+++ b/boilerplate/storybook/storybook.tsx
@@ -12,6 +12,11 @@ const StorybookUI = getStorybookUI({ port: 9001, host: "localhost", onDeviceUI: 
 export class StorybookUIRoot extends React.Component {
   componentDidMount() {
     SplashScreen.hide()
+    if (typeof __TEST__ === "undefined" || !__TEST__) {
+      const Reactotron = require("../src/services/reactotron")
+      const reactotron = new Reactotron.Reactotron()
+      reactotron.setup()
+    }
   }
   render() {
     return <StorybookUI />

--- a/boilerplate/test/__snapshots__/storyshots.test.ts.snap
+++ b/boilerplate/test/__snapshots__/storyshots.test.ts.snap
@@ -1466,7 +1466,7 @@ exports[`Storyshots FormRow Assembled 1`] = `
                 ellipsizeMode="tail"
                 style={
                   Object {
-                    "color": "#939AA4",
+                    "color": "#1d1d1d",
                     "fontFamily": "Montserrat",
                     "fontSize": 13,
                   }
@@ -1491,7 +1491,7 @@ exports[`Storyshots FormRow Assembled 1`] = `
                 ellipsizeMode="tail"
                 style={
                   Object {
-                    "color": "#ffffff",
+                    "color": "#1d1d1d",
                     "fontFamily": "Montserrat",
                     "fontSize": 15,
                   }
@@ -1516,7 +1516,7 @@ exports[`Storyshots FormRow Assembled 1`] = `
                 ellipsizeMode="tail"
                 style={
                   Object {
-                    "color": "#939AA4",
+                    "color": "#1d1d1d",
                     "fontFamily": "Montserrat",
                     "fontSize": 9,
                   }
@@ -1542,7 +1542,7 @@ exports[`Storyshots FormRow Assembled 1`] = `
                 ellipsizeMode="tail"
                 style={
                   Object {
-                    "color": "#ffffff",
+                    "color": "#1d1d1d",
                     "fontFamily": "Montserrat",
                     "fontSize": 15,
                   }
@@ -1655,7 +1655,7 @@ exports[`Storyshots FormRow Assembled 1`] = `
                 ellipsizeMode="tail"
                 style={
                   Object {
-                    "color": "#ffffff",
+                    "color": "#1d1d1d",
                     "fontFamily": "Montserrat",
                     "fontSize": 15,
                   }
@@ -1680,7 +1680,7 @@ exports[`Storyshots FormRow Assembled 1`] = `
                 ellipsizeMode="tail"
                 style={
                   Object {
-                    "color": "#ffffff",
+                    "color": "#1d1d1d",
                     "fontFamily": "Montserrat",
                     "fontSize": 15,
                   }
@@ -1706,7 +1706,7 @@ exports[`Storyshots FormRow Assembled 1`] = `
                 ellipsizeMode="tail"
                 style={
                   Object {
-                    "color": "#ffffff",
+                    "color": "#1d1d1d",
                     "fontFamily": "Montserrat",
                     "fontSize": 15,
                   }
@@ -1854,7 +1854,7 @@ exports[`Storyshots FormRow Presets 1`] = `
                 ellipsizeMode="tail"
                 style={
                   Object {
-                    "color": "#ffffff",
+                    "color": "#1d1d1d",
                     "fontFamily": "Montserrat",
                     "fontSize": 15,
                   }
@@ -1868,7 +1868,7 @@ exports[`Storyshots FormRow Presets 1`] = `
                 ellipsizeMode="tail"
                 style={
                   Object {
-                    "color": "#ffffff",
+                    "color": "#1d1d1d",
                     "fontFamily": "Montserrat",
                     "fontSize": 15,
                   }
@@ -1982,7 +1982,7 @@ exports[`Storyshots FormRow Presets 1`] = `
                 ellipsizeMode="tail"
                 style={
                   Object {
-                    "color": "#ffffff",
+                    "color": "#1d1d1d",
                     "fontFamily": "Montserrat",
                     "fontSize": 15,
                   }
@@ -2097,7 +2097,7 @@ exports[`Storyshots FormRow Presets 1`] = `
                 ellipsizeMode="tail"
                 style={
                   Object {
-                    "color": "#ffffff",
+                    "color": "#1d1d1d",
                     "fontFamily": "Montserrat",
                     "fontSize": 15,
                   }
@@ -2111,7 +2111,7 @@ exports[`Storyshots FormRow Presets 1`] = `
                 ellipsizeMode="tail"
                 style={
                   Object {
-                    "color": "#ffffff",
+                    "color": "#1d1d1d",
                     "fontFamily": "Montserrat",
                     "fontSize": 15,
                   }
@@ -2225,7 +2225,7 @@ exports[`Storyshots FormRow Presets 1`] = `
                 ellipsizeMode="tail"
                 style={
                   Object {
-                    "color": "#ffffff",
+                    "color": "#1d1d1d",
                     "fontFamily": "Montserrat",
                     "fontSize": 15,
                   }
@@ -2338,7 +2338,7 @@ exports[`Storyshots FormRow Presets 1`] = `
                 ellipsizeMode="tail"
                 style={
                   Object {
-                    "color": "#ffffff",
+                    "color": "#1d1d1d",
                     "fontFamily": "Montserrat",
                     "fontSize": 15,
                   }
@@ -2451,7 +2451,7 @@ exports[`Storyshots FormRow Presets 1`] = `
                 ellipsizeMode="tail"
                 style={
                   Object {
-                    "color": "#ffffff",
+                    "color": "#1d1d1d",
                     "fontFamily": "Montserrat",
                     "fontSize": 15,
                   }
@@ -2584,53 +2584,62 @@ exports[`Storyshots Header Behavior 1`] = `
             <View
               style={
                 Object {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                  "justifyContent": "flex-start",
-                  "paddingBottom": 24,
-                  "paddingHorizontal": 16,
-                  "paddingTop": 24,
+                  "backgroundColor": "#1d1d1d",
+                  "flex": 1,
                 }
               }
             >
               <View
                 style={
                   Object {
-                    "width": 32,
-                  }
-                }
-              />
-              <View
-                style={
-                  Object {
-                    "flex": 1,
-                    "justifyContent": "center",
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "justifyContent": "flex-start",
+                    "paddingBottom": 24,
+                    "paddingHorizontal": 16,
+                    "paddingTop": 24,
                   }
                 }
               >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
+                <View
                   style={
                     Object {
-                      "color": "#ffffff",
-                      "fontFamily": "Montserrat",
-                      "fontSize": 15,
-                      "textAlign": "center",
+                      "width": 32,
+                    }
+                  }
+                />
+                <View
+                  style={
+                    Object {
+                      "flex": 1,
+                      "justifyContent": "center",
                     }
                   }
                 >
-                  secondExampleScreen.howTo.test
-                </Text>
-              </View>
-              <View
-                style={
-                  Object {
-                    "width": 32,
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "color": "#ffffff",
+                        "fontFamily": "Montserrat",
+                        "fontSize": 15,
+                        "textAlign": "center",
+                      }
+                    }
+                  >
+                    secondExampleScreen.howTo.test
+                  </Text>
+                </View>
+                <View
+                  style={
+                    Object {
+                      "width": 32,
+                    }
                   }
-                }
-              />
+                />
+              </View>
             </View>
           </View>
         </View>
@@ -2724,77 +2733,86 @@ exports[`Storyshots Header Behavior 1`] = `
             <View
               style={
                 Object {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                  "justifyContent": "flex-start",
-                  "paddingBottom": 24,
-                  "paddingHorizontal": 16,
-                  "paddingTop": 24,
+                  "backgroundColor": "#1d1d1d",
+                  "flex": 1,
                 }
               }
             >
               <View
-                accessible={true}
-                isTVSelectable={true}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
                   Object {
-                    "alignItems": "flex-start",
-                    "borderRadius": 4,
-                    "justifyContent": "center",
-                    "opacity": 1,
-                    "paddingHorizontal": 0,
-                    "paddingVertical": 0,
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "justifyContent": "flex-start",
+                    "paddingBottom": 24,
+                    "paddingHorizontal": 16,
+                    "paddingTop": 24,
                   }
                 }
               >
-                <View>
-                  <Image
-                    source={1}
-                    style={
-                      Object {
-                        "resizeMode": "contain",
-                      }
-                    }
-                  />
-                </View>
-              </View>
-              <View
-                style={
-                  Object {
-                    "flex": 1,
-                    "justifyContent": "center",
-                  }
-                }
-              >
-                <Text
+                <View
                   accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
+                  isTVSelectable={true}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
                   style={
                     Object {
-                      "color": "#ffffff",
-                      "fontFamily": "Montserrat",
-                      "fontSize": 15,
-                      "textAlign": "center",
+                      "alignItems": "flex-start",
+                      "borderRadius": 4,
+                      "justifyContent": "center",
+                      "opacity": 1,
+                      "paddingHorizontal": 0,
+                      "paddingVertical": 0,
                     }
                   }
                 >
-                  secondExampleScreen.howTo.test
-                </Text>
-              </View>
-              <View
-                style={
-                  Object {
-                    "width": 32,
+                  <View>
+                    <Image
+                      source={1}
+                      style={
+                        Object {
+                          "resizeMode": "contain",
+                        }
+                      }
+                    />
+                  </View>
+                </View>
+                <View
+                  style={
+                    Object {
+                      "flex": 1,
+                      "justifyContent": "center",
+                    }
                   }
-                }
-              />
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "color": "#ffffff",
+                        "fontFamily": "Montserrat",
+                        "fontSize": 15,
+                        "textAlign": "center",
+                      }
+                    }
+                  >
+                    secondExampleScreen.howTo.test
+                  </Text>
+                </View>
+                <View
+                  style={
+                    Object {
+                      "width": 32,
+                    }
+                  }
+                />
+              </View>
             </View>
           </View>
         </View>
@@ -2888,75 +2906,84 @@ exports[`Storyshots Header Behavior 1`] = `
             <View
               style={
                 Object {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                  "justifyContent": "flex-start",
-                  "paddingBottom": 24,
-                  "paddingHorizontal": 16,
-                  "paddingTop": 24,
+                  "backgroundColor": "#1d1d1d",
+                  "flex": 1,
                 }
               }
             >
               <View
                 style={
                   Object {
-                    "width": 32,
-                  }
-                }
-              />
-              <View
-                style={
-                  Object {
-                    "flex": 1,
-                    "justifyContent": "center",
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "justifyContent": "flex-start",
+                    "paddingBottom": 24,
+                    "paddingHorizontal": 16,
+                    "paddingTop": 24,
                   }
                 }
               >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
+                <View
                   style={
                     Object {
-                      "color": "#ffffff",
-                      "fontFamily": "Montserrat",
-                      "fontSize": 15,
-                      "textAlign": "center",
+                      "width": 32,
+                    }
+                  }
+                />
+                <View
+                  style={
+                    Object {
+                      "flex": 1,
+                      "justifyContent": "center",
                     }
                   }
                 >
-                  secondExampleScreen.howTo.test
-                </Text>
-              </View>
-              <View
-                accessible={true}
-                isTVSelectable={true}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  Object {
-                    "alignItems": "flex-start",
-                    "borderRadius": 4,
-                    "justifyContent": "center",
-                    "opacity": 1,
-                    "paddingHorizontal": 0,
-                    "paddingVertical": 0,
-                  }
-                }
-              >
-                <View>
-                  <Image
-                    source={1}
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
                     style={
                       Object {
-                        "resizeMode": "contain",
+                        "color": "#ffffff",
+                        "fontFamily": "Montserrat",
+                        "fontSize": 15,
+                        "textAlign": "center",
                       }
                     }
-                  />
+                  >
+                    secondExampleScreen.howTo.test
+                  </Text>
+                </View>
+                <View
+                  accessible={true}
+                  isTVSelectable={true}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    Object {
+                      "alignItems": "flex-start",
+                      "borderRadius": 4,
+                      "justifyContent": "center",
+                      "opacity": 1,
+                      "paddingHorizontal": 0,
+                      "paddingVertical": 0,
+                    }
+                  }
+                >
+                  <View>
+                    <Image
+                      source={1}
+                      style={
+                        Object {
+                          "resizeMode": "contain",
+                        }
+                      }
+                    />
+                  </View>
                 </View>
               </View>
             </View>
@@ -3917,20 +3944,29 @@ exports[`Storyshots Text Passing Content 1`] = `
               }
             }
           >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
+            <View
               style={
                 Object {
-                  "color": "#ffffff",
-                  "fontFamily": "Montserrat",
-                  "fontSize": 15,
+                  "backgroundColor": "#1d1d1d",
+                  "flex": 1,
                 }
               }
             >
-              Heyo!
-            </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#ffffff",
+                    "fontFamily": "Montserrat",
+                    "fontSize": 15,
+                  }
+                }
+              >
+                Heyo!
+              </Text>
+            </View>
           </View>
         </View>
         <View
@@ -4020,34 +4056,43 @@ exports[`Storyshots Text Passing Content 1`] = `
               }
             }
           >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
+            <View
               style={
                 Object {
-                  "color": "#ffffff",
-                  "fontFamily": "Montserrat",
-                  "fontSize": 15,
+                  "backgroundColor": "#1d1d1d",
+                  "flex": 1,
                 }
               }
             >
-              common.ok.test
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#ffffff",
-                  "fontFamily": "Montserrat",
-                  "fontSize": 15,
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#ffffff",
+                    "fontFamily": "Montserrat",
+                    "fontSize": 15,
+                  }
                 }
-              }
-            >
-              omglol.test
-            </Text>
+              >
+                common.ok.test
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#ffffff",
+                    "fontFamily": "Montserrat",
+                    "fontSize": 15,
+                  }
+                }
+              >
+                omglol.test
+              </Text>
+            </View>
           </View>
         </View>
         <View
@@ -4137,20 +4182,29 @@ exports[`Storyshots Text Passing Content 1`] = `
               }
             }
           >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
+            <View
               style={
                 Object {
-                  "color": "#ffffff",
-                  "fontFamily": "Montserrat",
-                  "fontSize": 15,
+                  "backgroundColor": "#1d1d1d",
+                  "flex": 1,
                 }
               }
             >
-              Passing strings as children.
-            </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#ffffff",
+                    "fontFamily": "Montserrat",
+                    "fontSize": 15,
+                  }
+                }
+              >
+                Passing strings as children.
+              </Text>
+            </View>
           </View>
         </View>
         <View
@@ -4240,20 +4294,14 @@ exports[`Storyshots Text Passing Content 1`] = `
               }
             }
           >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
+            <View
               style={
                 Object {
-                  "color": "#ffffff",
-                  "fontFamily": "Montserrat",
-                  "fontSize": 15,
+                  "backgroundColor": "#1d1d1d",
+                  "flex": 1,
                 }
               }
             >
-               
-              Hello 
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -4263,14 +4311,29 @@ exports[`Storyshots Text Passing Content 1`] = `
                     "color": "#ffffff",
                     "fontFamily": "Montserrat",
                     "fontSize": 15,
-                    "fontWeight": "bold",
                   }
                 }
               >
-                bolded
+                 
+                Hello 
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#ffffff",
+                      "fontFamily": "Montserrat",
+                      "fontSize": 15,
+                      "fontWeight": "bold",
+                    }
+                  }
+                >
+                  bolded
+                </Text>
+                 World.
               </Text>
-               World.
-            </Text>
+            </View>
           </View>
         </View>
       </View>
@@ -4392,70 +4455,79 @@ exports[`Storyshots Text Style Presets 1`] = `
               }
             }
           >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
+            <View
               style={
                 Object {
-                  "color": "#ffffff",
-                  "fontFamily": "Montserrat",
-                  "fontSize": 15,
+                  "backgroundColor": "#1d1d1d",
+                  "flex": 1,
                 }
               }
             >
-              Hello!
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#ffffff",
-                  "fontFamily": "Montserrat",
-                  "fontSize": 15,
-                  "paddingTop": 10,
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#ffffff",
+                    "fontFamily": "Montserrat",
+                    "fontSize": 15,
+                  }
                 }
-              }
-            >
-              Check out
-              
+              >
+                Hello!
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#ffffff",
+                    "fontFamily": "Montserrat",
+                    "fontSize": 15,
+                    "paddingTop": 10,
+                  }
+                }
+              >
+                Check out
+                
 
-              my
-              
+                my
+                
 
-              line height
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#ffffff",
-                  "fontFamily": "Montserrat",
-                  "fontSize": 15,
-                  "paddingTop": 10,
+                line height
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#ffffff",
+                    "fontFamily": "Montserrat",
+                    "fontSize": 15,
+                    "paddingTop": 10,
+                  }
                 }
-              }
-            >
-              The quick brown fox jumped over the slow lazy dog.
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#ffffff",
-                  "fontFamily": "Montserrat",
-                  "fontSize": 15,
+              >
+                The quick brown fox jumped over the slow lazy dog.
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#ffffff",
+                    "fontFamily": "Montserrat",
+                    "fontSize": 15,
+                  }
                 }
-              }
-            >
-              $123,456,789.00
-            </Text>
+              >
+                $123,456,789.00
+              </Text>
+            </View>
           </View>
         </View>
         <View
@@ -4545,21 +4617,30 @@ exports[`Storyshots Text Style Presets 1`] = `
               }
             }
           >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
+            <View
               style={
                 Object {
-                  "color": "#ffffff",
-                  "fontFamily": "Montserrat",
-                  "fontSize": 15,
-                  "fontWeight": "bold",
+                  "backgroundColor": "#1d1d1d",
+                  "flex": 1,
                 }
               }
             >
-              Osnap! I'm puffy.
-            </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#ffffff",
+                    "fontFamily": "Montserrat",
+                    "fontSize": 15,
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                Osnap! I'm puffy.
+              </Text>
+            </View>
           </View>
         </View>
         <View
@@ -4649,21 +4730,30 @@ exports[`Storyshots Text Style Presets 1`] = `
               }
             }
           >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
+            <View
               style={
                 Object {
-                  "color": "#ffffff",
-                  "fontFamily": "Montserrat",
-                  "fontSize": 24,
-                  "fontWeight": "bold",
+                  "backgroundColor": "#1d1d1d",
+                  "flex": 1,
                 }
               }
             >
-              Behold!
-            </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#ffffff",
+                    "fontFamily": "Montserrat",
+                    "fontSize": 24,
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                Behold!
+              </Text>
+            </View>
           </View>
         </View>
       </View>
@@ -4807,7 +4897,7 @@ exports[`Storyshots TextField Labelling 1`] = `
                 Name
               </Text>
               <TextInput
-                allowFontScaling={true}
+                autoFocus={false}
                 onChangeText={[Function]}
                 placeholder="omg your name"
                 placeholderTextColor="#CDD4DA"
@@ -4935,7 +5025,7 @@ exports[`Storyshots TextField Labelling 1`] = `
                 storybook.field.test
               </Text>
               <TextInput
-                allowFontScaling={true}
+                autoFocus={false}
                 onChangeText={[Function]}
                 placeholder="storybook.placeholder.test"
                 placeholderTextColor="#CDD4DA"
@@ -5097,7 +5187,7 @@ exports[`Storyshots TextField Style Overrides 1`] = `
                 First Name
               </Text>
               <TextInput
-                allowFontScaling={true}
+                autoFocus={false}
                 onChangeText={[Function]}
                 placeholderTextColor="#CDD4DA"
                 style={
@@ -5136,7 +5226,7 @@ exports[`Storyshots TextField Style Overrides 1`] = `
                 Last Name
               </Text>
               <TextInput
-                allowFontScaling={true}
+                autoFocus={false}
                 onChangeText={[Function]}
                 placeholderTextColor="#CDD4DA"
                 style={
@@ -5263,7 +5353,7 @@ exports[`Storyshots TextField Style Overrides 1`] = `
                 Name
               </Text>
               <TextInput
-                allowFontScaling={true}
+                autoFocus={false}
                 onChangeText={[Function]}
                 placeholderTextColor="#CDD4DA"
                 style={

--- a/boilerplate/test/mock-textinput.ts
+++ b/boilerplate/test/mock-textinput.ts
@@ -1,0 +1,12 @@
+jest.mock("TextInput", () => {
+  const RealComponent = require.requireActual("TextInput")
+  const React = require("React")
+
+  class TextInput extends React.Component {
+    render() {
+      return React.createElement("TextInput", {...this.props, autoFocus: false}, this.props.children)
+    }
+  }
+  TextInput.propTypes = RealComponent.propTypes
+  return TextInput
+})

--- a/boilerplate/test/setup.ts
+++ b/boilerplate/test/setup.ts
@@ -4,3 +4,8 @@ import "react-native"
 // libraries to mock
 import "./mock-i18n"
 import "./mock-reactotron"
+import "./mock-textinput"
+
+declare global {
+  var __TEST__
+}


### PR DESCRIPTION
New Trello Board link: https://trello.com/c/YPZKngqg/28-configure-reactotron-in-storybook

Closes https://github.com/infinitered/ignite-ir-boilerplate-bowser/pull/81

Implements add-reactotron-to-storybook based on Kevin's suggestion in https://github.com/infinitered/ignite-ir-boilerplate-bowser/pull/81

Reactotron now executes when running storybook tests. It shuts off as expected when running `yarn test`.

This PR fixes this  test warning:

"console.warn node_modules/react-native/jest/setup.js:91
      Calling .blur() in the test renderer environment is not supported. Instead, mock out your components that use findNodeHandle with replacements that don't rely on the native environment."
by adding a new mock for text-input "mock-textinput.ts" that sets the "autoFocus" prop to false when tests are running.

Fixed a bunch of rendering issues with Storybook tests.

(1) The default color of the Text component is white, which is not visible in the storybook tests.
(2) missing en_US translations for the text-field.story.

What follows is screenshots for all fixed Storybook renderings:

![formrowassembled](https://user-images.githubusercontent.com/144869/45310625-a5f5ff80-b4db-11e8-95b7-f3ab328187df.png)

![formrowpresets](https://user-images.githubusercontent.com/144869/45310641-aee6d100-b4db-11e8-8278-ff884957482d.png)

![headerbehavior](https://user-images.githubusercontent.com/144869/45310642-aee6d100-b4db-11e8-9dde-0187565b7857.png)

![textfieldstyleoverrides](https://user-images.githubusercontent.com/144869/45310643-aee6d100-b4db-11e8-8368-6aaf3269f35c.png)

![textfiieldlabelling](https://user-images.githubusercontent.com/144869/45310644-aee6d100-b4db-11e8-8dce-24795f082404.png)

![textpassingcontent](https://user-images.githubusercontent.com/144869/45310645-af7f6780-b4db-11e8-9f97-a9830a535f97.png)

![textstylepresets](https://user-images.githubusercontent.com/144869/45310646-af7f6780-b4db-11e8-8e82-3a032edc0316.png)
