### PR TITLE
Switch example API to from GitHub to Typicode JSON example api

### DIFF
--- a/boilerplate/src/services/api/api-config.ts
+++ b/boilerplate/src/services/api/api-config.ts
@@ -19,6 +19,6 @@ export interface ApiConfig {
  * The default configuration for the app.
  */
 export const DEFAULT_API_CONFIG: ApiConfig = {
-  url: env.API || "https://api.github.com",
+  url: env.API || "https://jsonplaceholder.typicode.com",
   timeout: 10000,
 }

--- a/boilerplate/src/services/api/api.ts
+++ b/boilerplate/src/services/api/api.ts
@@ -39,17 +39,48 @@ export class Api {
       baseURL: this.config.url,
       timeout: this.config.timeout,
       headers: {
-        Accept: "application/vnd.github.v3+json",
+        Accept: "application/json",
       },
     })
   }
 
   /**
-   * Gets a list of repos.
+   * Gets a list of users.
    */
-  async getRepo(repo: string): Promise<Types.GetRepoResult> {
+  async getUsers(): Promise<Types.GetUsersResult> {
     // make the api call
-    const response: ApiResponse<any> = await this.apisauce.get(`/repos/${repo}`)
+    const response: ApiResponse<any> = await this.apisauce.get(`/users`)
+
+    // the typical ways to die when calling an api
+    if (!response.ok) {
+      const problem = getGeneralApiProblem(response)
+      if (problem) return problem
+    }
+
+    const convertUser = raw => {
+      return {
+        id: raw.id,
+        name: raw.name,
+      }
+    }
+
+    // transform the data into the format we are expecting
+    try {
+      const rawUsers = response.data
+      const resultUsers: Types.User[] = rawUsers.map(convertUser)
+      return { kind: "ok", users: resultUsers }
+    } catch {
+      return { kind: "bad-data" }
+    }
+  }
+
+  /**
+   * Gets a single user by ID
+   */
+
+  async getUser(id: string): Promise<Types.GetUserResult> {
+    // make the api call
+    const response: ApiResponse<any> = await this.apisauce.get(`/users/${id}`)
 
     // the typical ways to die when calling an api
     if (!response.ok) {
@@ -59,12 +90,11 @@ export class Api {
 
     // transform the data into the format we are expecting
     try {
-      const resultRepo: Types.Repo = {
+      const resultUser: Types.User = {
         id: response.data.id,
         name: response.data.name,
-        owner: response.data.owner.login,
       }
-      return { kind: "ok", repo: resultRepo }
+      return { kind: "ok", user: resultUser }
     } catch {
       return { kind: "bad-data" }
     }

--- a/boilerplate/src/services/api/api.types.ts
+++ b/boilerplate/src/services/api/api.types.ts
@@ -1,9 +1,9 @@
 import { GeneralApiProblem } from "./api-problem"
 
-export interface Repo {
+export interface User {
   id: number
   name: string
-  owner: string
 }
 
-export type GetRepoResult = { kind: "ok"; repo: Repo } | GeneralApiProblem
+export type GetUsersResult = { kind: "ok"; users: User[] } | GeneralApiProblem
+export type GetUserResult = { kind: "ok"; user: User } | GeneralApiProblem

--- a/boilerplate/src/views/example/second-example-screen/second-example-screen.tsx
+++ b/boilerplate/src/views/example/second-example-screen/second-example-screen.tsx
@@ -109,7 +109,7 @@ export class SecondExampleScreen extends React.Component<SecondExampleScreenProp
     // Don't do API like this, use store's API
     const demo = new Api()
     demo.setup()
-    demo.getRepo("infinitered/ignite")
+    demo.getUser("1")
     // Let's do some async storage stuff
     await save("Cool Name", "Boaty McBoatface")
   }
@@ -138,7 +138,7 @@ export class SecondExampleScreen extends React.Component<SecondExampleScreenProp
                 textStyle={DEMO_TEXT}
                 tx="secondExampleScreen.reactotron"
                 onPress={this.demoReactotron}
-                />
+              />
             </View>
             <Image source={logoIgnite} style={IGNITE} />
             <View style={LOVE_WRAPPER}>


### PR DESCRIPTION
This is for #92 

Quote for convenience:

"Github has a really great, robust REST API.

However, it doesn't feel like it makes the most ideal example API for Ignite.

    - Repos aren't super relatable as a data type, compared to, say, users
    - It has some custom configuration, like it's custom Content-Type: application/vnd.github.v3+json which can be confusing if you're trying to transform our example into your own API service .

I'm proposing switching the sample API to https://jsonplaceholder.typicode.com/, which is designed to be a sample, and supports straight REST endpoints for data types like users, todos, posts and other familiar example concepts."

<img width="1077" alt="screen shot 2018-09-18 at 2 30 30 pm" src="https://user-images.githubusercontent.com/6894653/45717638-6f5d5c00-bb4f-11e8-9f9f-f9869dfb2988.png">

