### PR TITLE
Add a few more Reactotron mocks, to make Typescript happier

### DIFF
--- a/boilerplate/src/services/reactotron/reactotron.ts
+++ b/boilerplate/src/services/reactotron/reactotron.ts
@@ -24,17 +24,20 @@ if (__DEV__) {
 } else {
   // attach a mock so if things sneaky by our __DEV__ guards, we won't crash.
   console.tron = {
+    benchmark: noop,
+    clear: noop,
+    close: noop,
     configure: noop,
     connect: noop,
-    use: noop,
-    useReactNative: noop,
-    clear: noop,
-    log: noop,
-    logImportant: noop,
     display: noop,
     error: noop,
     image: noop,
+    log: noop,
+    logImportant: noop,
     reportError: noop,
+    use: noop,
+    useReactNative: noop,
+    warn: noop,
   }
 }
 


### PR DESCRIPTION
With a newly-generated project, typescript was complaining about `src/services/reactotron/reactotron.ts`:

```
Type '{ configure: () => any; connect: () => any; use: () => any; useReactNative: () => any; clear: () => any; log: () => any; logImportant: () => any; display: () => any; error: () => any; image: () => any; reportError: () => any; }' is not assignable to type 'Reactotron'.
  Property 'close' is missing in type '{ configure: () => any; connect: () => any; use: () => any; useReactNative: () => any; clear: () => any; log: () => any; logImportant: () => any; display: () => any; error: () => any; image: () => any; reportError: () => any; }'.
```

Once I added `close`, it complained about `warn`, then `benchmark`, so I added those too.

I also sorted the list, because I’m OCD that way.