### PR TITLE
[@types] Change: Use *Props instead of *Properties (deprecated)

### DIFF
--- a/boilerplate/src/views/shared/button/button.props.ts
+++ b/boilerplate/src/views/shared/button/button.props.ts
@@ -1,7 +1,7 @@
-import { ViewStyle, TextStyle, TouchableOpacityProperties } from "react-native"
+import { ViewStyle, TextStyle, TouchableOpacityProps } from "react-native"
 import { ButtonPresetNames } from "./button.presets"
 
-export interface ButtonProps extends TouchableOpacityProperties {
+export interface ButtonProps extends TouchableOpacityProps {
   /**
    * Text which is looked up via i18n.
    */

--- a/boilerplate/src/views/shared/text-field/text-field.props.ts
+++ b/boilerplate/src/views/shared/text-field/text-field.props.ts
@@ -1,6 +1,6 @@
-import { TextInputProperties, TextStyle, ViewStyle } from "react-native"
+import { TextInputProps, TextStyle, ViewStyle } from "react-native"
 
-export interface TextFieldProps extends TextInputProperties {
+export interface TextFieldProps extends TextInputProps {
   /**
    * The placeholder i18n key.
    */

--- a/boilerplate/src/views/shared/text/text.props.ts
+++ b/boilerplate/src/views/shared/text/text.props.ts
@@ -1,4 +1,4 @@
-import { TextStyle, TextProperties } from "react-native"
+import { TextStyle, TextProps as TextProperties } from "react-native"
 import { TextPresets } from "./text.presets"
 
 export interface TextProps extends TextProperties {


### PR DESCRIPTION
Previously, props interfaces where named *Properties
They have been renamed to *Props to match React Native documentation
The following lines ensure compatibility with *Properties and should be removed in the future

Reference: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-native/legacy-properties.d.ts