### PR TITLE
Always stringify value before passing to `AsyncStorage.setItem()` in `storage.save`

### DIFF
--- a/boilerplate/src/lib/storage/storage.ts
+++ b/boilerplate/src/lib/storage/storage.ts
@@ -51,11 +51,7 @@ export async function load(key: string): Promise<any | null> {
  */
 export async function save(key: string, value: any): Promise<boolean> {
   try {
-    if (typeof value === "object") {
-      await AsyncStorage.setItem(key, JSON.stringify(value))
-    } else {
-      await AsyncStorage.setItem(key, value)
-    }
+    await AsyncStorage.setItem(key, JSON.stringify(value))
     return true
   } catch {
     return false


### PR DESCRIPTION
If you call `storage.save("someKey", 1)` on iOS -- you'll get a runtime exception about an unrecognized selector being thrown while `invoking multiSet on target AsyncLocalStorage with params (...`.

`AsyncStorage.setItem()` can only take string values -- the existing check of `typeof === 'object'` will return `false` if you try it with a number, and then `AsyncStorage.setItem()` will be called with the number argument, which is what causes this exception.

It's safe to call `JSON.stringify` on numbers and strings -- it'll always return a serialized string, so we can sidestep this issue completely.