### PR TITLE
Call react-native link with spawn instead of run

### DIFF
--- a/boilerplate.js
+++ b/boilerplate.js
@@ -222,7 +222,7 @@ async function install(context) {
   spinner.succeed(`Installed dependencies`)
 
   // re-run react-native link
-  await system.run('react-native link')
+  await system.spawn('react-native link', { stdio: 'ignore' })
   spinner.succeed(`Linked dependencies`)
 
   const perfDuration = parseInt(((new Date()).getTime() - perfStart) / 10) / 100


### PR DESCRIPTION
Fixes: https://github.com/infinitered/ignite-ir-boilerplate-bowser/issues/120

We are calling `react-native link` with spawn on [line 166](https://github.com/infinitered/ignite-ir-boilerplate-bowser/blob/ce622b781c83e4e0a479714fc83afcc0dd492e1d/boilerplate.js#L166). Calling it the second time with spawn fixes the maximum call stack size exceeded error. 