### PR TITLE
fix: Pick up updated mobx-state-tree to avoid error

### DIFF
--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -43,7 +43,7 @@
     "lodash.throttle": "4.1.1",
     "mobx": "^6.0.2",
     "mobx-react-lite": "^3.0.1",
-    "mobx-state-tree": "^4.0.1-rc.1",
+    "mobx-state-tree": "^5.0.1",
     "ramda": "0.27.1",
     "react-native-splash-screen": "3.2.0",
     "reactotron-mst": "^3.1.3",


### PR DESCRIPTION
The current boilerplate has the error reported in https://github.com/mobxjs/mobx-state-tree/issues/1653 when starting up.  This change picks up the fixed version of mobx-state-tree.